### PR TITLE
Adds testing packages to package.json devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
     "crowsnest-rules-aws": "0.0.1",
     "lambda-cfn": "0.0.1"
   },
+  "devDependencies": {
+    "jscs": "2.11.0",
+    "jshint": "2.9.1",
+    "tape": "4.5.1"
+  },
   "jscsConfig": {
     "preset": "airbnb",
     "requireCamelCaseOrUpperCaseIdentifiers": null


### PR DESCRIPTION
Adds the following linting and testing packages to the `devDependencies` section of the `package.json`:
- jscs (used in `pretest` command)
- jshint (used in `pretest` command)
- tape (used in `test` command)

This makes running `npm test` easier for people who may not have the above packages installed globally.

I ran into the issue since I use nvm. These testing modules were installed globally on my machine on a different version of Node (0.10.40) than the version (0.10.38) used by Crow's Nest.

@ianshward @zmully
