### PR TITLE
bump lambda-cfn to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "crowsnest-rules-aws": "0.0.1",
-    "lambda-cfn": "0.0.2"
+    "lambda-cfn": "0.0.4"
   },
   "devDependencies": {
     "jscs": "2.11.0",


### PR DESCRIPTION
This just moves to latest version of lambda-cfn.  Bug fixes in that version do not affect anything in this repo.
